### PR TITLE
:rocket: Add Docker server management functionality

### DIFF
--- a/Foundry.sh
+++ b/Foundry.sh
@@ -35,9 +35,10 @@ show_main_menu() {
     echo -e "${GREEN}3)${NC} Start all servers"
     echo -e "${BLUE}4)${NC} Stop all servers"
     echo -e "${CYAN}5)${NC} Check servers status (soon)"
-    echo -e "${RED}6)${NC} Exit"
+    echo -e "${MAGENTA}6)${NC} Docker servers"
+    echo -e "${RED}7)${NC} Exit"
     echo
-    echo -n "Enter your choice [1-6]: "
+    echo -n "Enter your choice [1-7]: "
 }
 
 # Function to check and download the dedicated server binary
@@ -282,6 +283,33 @@ check_servers_status() {
     read -p "Press Enter to return to main menu..."
 }
 
+# Function to handle Docker operations
+docker_servers() {
+    show_header
+    echo -e "${MAGENTA}=== Docker Servers ===${NC}"
+    echo
+
+    # First check and download the binary if needed
+    if ! check_and_download_binary; then
+        return 1
+    fi
+
+    if [[ -f "./scripts/docker_server.sh" ]]; then
+        # Ensure script has execute permissions
+        chmod +x "./scripts/docker_server.sh"
+        echo -e "${BLUE}Launching Docker server script...${NC}"
+        echo
+        ./scripts/docker_server.sh
+    else
+        echo -e "${RED}✗ scripts/docker_server.sh not found${NC}"
+        read -p "Press Enter to return to main menu..."
+        return 1
+    fi
+
+    echo
+    read -p "Press Enter to return to main menu..."
+}
+
 # Main program loop
 main() {
     while true; do
@@ -307,6 +335,9 @@ main() {
                 check_servers_status
                 ;;
             6)
+            docker_servers
+                ;;
+            7)
                 echo
                 echo -e "${CYAN}Thank you for using StarDeception Game Server Manager!${NC}"
                 echo -e "${CYAN}Goodbye!${NC}"
@@ -314,7 +345,7 @@ main() {
                 ;;
             *)
                 echo
-                echo -e "${RED}Invalid option. Please select 1-6.${NC}"
+                echo -e "${RED}Invalid option. Please select 1-7.${NC}"
                 sleep 2
                 ;;
         esac
@@ -322,10 +353,10 @@ main() {
 }
 
 # Check if we're in the right directory
-if [[ ! -f "./scripts/create_servers.sh" ]] || [[ ! -f "./scripts/delete_servers.sh" ]] || [[ ! -f "./scripts/start_all_servers.sh" ]]; then
+if [[ ! -f "./scripts/create_servers.sh" ]] || [[ ! -f "./scripts/delete_servers.sh" ]] || [[ ! -f "./scripts/start_all_servers.sh" ]] || [[ ! -f "./scripts/docker_server.sh" ]]; then
     echo -e "${RED}✗ Error: Required scripts not found in scripts/ directory${NC}"
     echo "Please make sure you're running this script from the Foundry directory"
-    echo "and that scripts/create_servers.sh, scripts/delete_servers.sh, and scripts/start_all_servers.sh exist."
+    echo "and that scripts/create_servers.sh, scripts/delete_servers.sh, scripts/start_all_servers.sh, and scripts/docker_server.sh exist."
     exit 1
 fi
 

--- a/README.md
+++ b/README.md
@@ -63,3 +63,4 @@ This project is licensed under the MIT License - see the [LICENSE](LICENSE) file
 ## 👨‍💻 Contributor
 
 **Foundry developed by [𝕭𝖗𝖚𝖒𝖊](https://noasecond.com)**
+**Docker integration developed by [BreizhHardware](https://mrqt.fr)**

--- a/scripts/docker_server.sh
+++ b/scripts/docker_server.sh
@@ -1,0 +1,283 @@
+#!/bin/bash
+
+# Colors for better UX
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+BLUE='\033[0;34m'
+CYAN='\033[0;36m'
+NC='\033[0m' # No Color
+
+# Function to check if Docker is installed
+check_docker_installed() {
+    if ! command -v docker &> /dev/null; then
+        return 1
+    else
+        return 0
+    fi
+}
+
+# Function to create Dockerfile
+create_dockerfile() {
+    # Create the Dockerfile in the parent directory (script_deploy_game_server/)
+    cat > Dockerfile << EOL
+# Use a lightweight base image
+FROM debian:latest
+
+# Install necessary dependencies
+RUN apt-get update && apt-get install -y procps && apt-get clean && rm -rf /var/lib/apt/lists/*
+
+# Set working directory
+WORKDIR /app
+
+# Copy necessary files
+# Note: Dockerfile is in script_deploy_game_server/, so src/ is relative to that
+COPY src/StarDeception.dedicated_server.sh /app/
+COPY src/StarDeception.dedicated_server.x86_64 /app/
+# server.ini will be mounted as volume
+
+# Make scripts executable
+RUN chmod +x /app/StarDeception.dedicated_server.sh
+RUN chmod +x /app/StarDeception.dedicated_server.x86_64
+
+# Ports will be mapped at runtime
+
+# Command to launch server
+CMD ["./StarDeception.dedicated_server.sh"]
+EOL
+}
+
+# Function to create and run a Docker container for a server
+create_run_container() {
+    local dir=$1
+    local image_name=$2
+    local server_name=$(basename "$dir")
+    echo -e "${BLUE}Creating Docker container for $server_name...${NC}"
+    
+    # Get server port from server.ini
+    local server_port=$(grep -oP "(?<=port=)[0-9]+" "$dir/server.ini" 2>/dev/null || echo "7050")
+    
+    # Check if container already exists
+    if docker ps -a --format '{{.Names}}' | grep -q "^stardeception-$server_name$"; then
+        echo -e "${YELLOW}  ⚠ Container already exists. Removing it...${NC}"
+        docker rm -f "stardeception-$server_name" > /dev/null
+    fi
+    
+    # Run Docker container
+    docker run -d --name "stardeception-$server_name" \
+        -p "$server_port:$server_port/tcp" \
+        -p "$server_port:$server_port/udp" \
+        -v "$dir/server.ini:/app/server.ini" \
+        "$image_name"
+    
+    if [ $? -eq 0 ]; then
+        echo -e "${GREEN}  ✓ Docker container started for $server_name on port $server_port${NC}"
+        return 0
+    else
+        echo -e "${RED}  ✗ Failed to start Docker container for $server_name${NC}"
+        return 1
+    fi
+}
+
+# Function to install Docker based on the OS package manager
+install_docker() {
+    echo -e "${BLUE}Docker is not installed. Attempting automatic installation...${NC}"
+    
+    # Detect package manager
+    if command -v apt &> /dev/null; then
+        # Check if it's Ubuntu or Debian
+        if grep -q "Ubuntu" /etc/os-release; then
+            echo -e "${BLUE}Installing Docker on Ubuntu via apt...${NC}"
+            sudo apt update
+            sudo apt install -y ca-certificates curl
+            sudo install -m 0755 -d /etc/apt/keyrings
+            sudo curl -fsSL https://download.docker.com/linux/ubuntu/gpg -o /etc/apt/keyrings/docker.asc
+            sudo chmod a+r /etc/apt/keyrings/docker.asc
+            echo "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/docker.asc] https://download.docker.com/linux/ubuntu $(. /etc/os-release && echo "$VERSION_CODENAME") stable" | sudo tee /etc/apt/sources.list.d/docker.list > /dev/null
+            sudo apt update
+            sudo apt install -y docker-ce docker-ce-cli containerd.io docker-buildx-plugin docker-compose-plugin
+        elif grep -q "Debian" /etc/os-release; then
+            echo -e "${BLUE}Installing Docker on Debian via apt...${NC}"
+            sudo apt update
+            sudo apt install -y ca-certificates curl gnupg
+            sudo install -m 0755 -d /etc/apt/keyrings
+            sudo curl -fsSL https://download.docker.com/linux/debian/gpg -o /etc/apt/keyrings/docker.asc
+            sudo chmod a+r /etc/apt/keyrings/docker.asc
+            echo "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/docker.asc] https://download.docker.com/linux/debian $(. /etc/os-release && echo "$VERSION_CODENAME") stable" | sudo tee /etc/apt/sources.list.d/docker.list > /dev/null
+            sudo apt update
+            sudo apt install -y docker-ce docker-ce-cli containerd.io docker-buildx-plugin docker-compose-plugin
+        else
+            echo -e "${BLUE}Installing Docker on general Debian-based system via apt...${NC}"
+            sudo apt update
+            sudo apt install -y docker.io
+        fi
+    elif command -v dnf &> /dev/null; then
+        echo -e "${BLUE}Installing Docker via dnf...${NC}"
+        sudo dnf -y install dnf-plugins-core
+        sudo dnf config-manager --add-repo https://download.docker.com/linux/fedora/docker-ce.repo
+        sudo dnf install -y docker-ce docker-ce-cli containerd.io
+    elif command -v yum &> /dev/null; then
+        echo -e "${BLUE}Installing Docker via yum...${NC}"
+        sudo yum install -y yum-utils
+        sudo yum-config-manager --add-repo https://download.docker.com/linux/centos/docker-ce.repo
+        sudo yum install -y docker-ce docker-ce-cli containerd.io
+    else
+        echo -e "${RED}✗ Unable to determine package manager.${NC}"
+        echo -e "${YELLOW}Please install 'Docker' manually and run this script again.${NC}"
+        echo -e "${BLUE}Common installation commands:${NC}"
+        echo "  • Debian/Ubuntu: https://docs.docker.com/engine/install/ubuntu/"
+        echo "  • Fedora: https://docs.docker.com/engine/install/fedora/"
+        echo "  • CentOS/RHEL: https://docs.docker.com/engine/install/centos/"
+        exit 1
+    fi
+
+    # Start Docker service
+    sudo systemctl start docker
+    sudo systemctl enable docker
+    
+    # Add current user to docker group to avoid using sudo for docker commands
+    sudo usermod -aG docker $(whoami)
+    echo -e "${YELLOW}⚠ For group changes to take effect, please log out and log back in, or restart your session.${NC}"
+}
+
+# Check and install Docker if necessary
+if ! check_docker_installed; then
+    install_docker
+    
+    # Check if installation was successful
+    if ! check_docker_installed; then
+        echo -e "${RED}✗ Docker installation failed.${NC}"F
+        exit 1
+    else
+        echo -e "${GREEN}✓ Docker has been successfully installed.${NC}"
+    fi
+else
+    echo -e "${GREEN}✓ Docker is already installed.${NC}"
+fi
+
+echo -e "${GREEN}========== Docker Server Creation and Execution ==========${NC}"
+echo
+
+# Current working directory is: /workspaces/SDO/script_deploy_game_server/
+# When the script is called by StarDeception_GameServer.sh
+
+# Check if dedicated server binary exists
+binary_file="src/StarDeception.dedicated_server.x86_64"
+if [[ ! -f "$binary_file" ]]; then
+    echo -e "${RED}✗ Dedicated server binary not found: $binary_file${NC}"
+    echo -e "${YELLOW}Please make sure the binary is downloaded and placed in the src/ directory.${NC}"
+    echo -e "${BLUE}Tip: Use the main menu option to automatically download the binary.${NC}"
+    exit 1
+fi
+
+echo -e "${GREEN}✓ Dedicated server binary found${NC}"
+
+# Check if dedicated server script exists
+script_file="src/StarDeception.dedicated_server.sh"
+if [[ ! -f "$script_file" ]]; then
+    echo -e "${RED}✗ Dedicated server script not found: $script_file${NC}"
+    echo -e "${YELLOW}Please make sure the server script is in the src/ directory.${NC}"
+    exit 1
+fi
+
+echo -e "${GREEN}✓ Dedicated server script found${NC}"
+
+# Find all server directories
+server_dirs=($(find . -maxdepth 1 -type d -name "server*" | sort))
+
+if [ ${#server_dirs[@]} -eq 0 ]; then
+    echo -e "${RED}No server directories found. Please run create new servers first.${NC}"
+    exit 1
+fi
+
+echo -e "${BLUE}Found ${#server_dirs[@]} server(s):${NC}"
+for dir in "${server_dirs[@]}"; do
+    echo "  - $dir"
+done
+echo
+
+# Options menu
+echo -e "${CYAN}What would you like to do?${NC}"
+echo "1. Create and run all servers as Docker containers"
+echo "2. Stop all Docker containers"
+echo "3. Remove all Docker containers"
+echo "4. Show running Docker containers"
+echo "5. Exit"
+read -p "Choose an option [1-5]: " option
+
+case $option in
+    1)
+        echo -e "${BLUE}Creating and running all servers as Docker containers...${NC}"
+        
+        # Create the Dockerfile in the parent directory
+        create_dockerfile
+        
+        # Build the base image just once
+        image_name="stardeception-base"
+        echo -e "${BLUE}Building base Docker image...${NC}"
+        
+        # Build from parent directory
+        docker build -t "$image_name" .
+        build_result=$?
+        
+        if [ $build_result -ne 0 ]; then
+            echo -e "${RED}✗ Failed to build Docker image${NC}"
+            exit 1
+        else
+            echo -e "${GREEN}✓ Docker image built successfully${NC}"
+        fi
+        
+        # Start each server as a Docker container
+        success_count=0
+        for dir in "${server_dirs[@]}"; do
+            if create_run_container "$dir" "$image_name"; then
+                ((success_count++))
+            fi
+        done
+        
+        echo -e "${GREEN}✓ Created and started $success_count out of ${#server_dirs[@]} Docker containers${NC}"
+        ;;
+    2)
+        echo -e "${BLUE}Stopping all StarDeception Docker containers...${NC}"
+        containers=$(docker ps -a --filter "name=stardeception-" -q)
+        
+        if [ -z "$containers" ]; then
+            echo -e "${YELLOW}No StarDeception containers found.${NC}"
+        else
+            docker stop $containers
+            echo -e "${GREEN}✓ All StarDeception containers have been stopped.${NC}"
+        fi
+        ;;
+    3)
+        echo -e "${BLUE}Removing all StarDeception Docker containers...${NC}"
+        containers=$(docker ps -a --filter "name=stardeception-" -q)
+        
+        if [ -z "$containers" ]; then
+            echo -e "${YELLOW}No StarDeception containers found.${NC}"
+        else
+            docker rm -f $containers
+            echo -e "${GREEN}✓ All StarDeception containers have been removed.${NC}"
+        fi
+        ;;
+    4)
+        echo -e "${BLUE}Running StarDeception containers:${NC}"
+        docker ps --filter "name=stardeception-"
+        ;;
+    5)
+        echo -e "${YELLOW}Goodbye!${NC}"
+        exit 0
+        ;;
+    *)
+        echo -e "${RED}Invalid option!${NC}"
+        exit 1
+        ;;
+esac
+
+echo
+echo -e "${BLUE}📋 Docker container management tips:${NC}"
+echo "  • To view container logs: docker logs <container_name>"
+echo "  • To enter a container: docker exec -it <container_name> bash"
+echo "  • To stop a container: docker stop <container_name>"
+echo "  • To remove a container: docker rm <container_name>"
+echo "  • To list all images: docker images"
+echo "  • To remove an image: docker rmi <image_id>"

--- a/scripts/setup_permissions.sh
+++ b/scripts/setup_permissions.sh
@@ -38,6 +38,9 @@ echo -e "${GREEN}✓ repair_servers.sh${NC}"
 chmod +x status_servers.sh
 echo -e "${GREEN}✓ status_servers.sh${NC}"
 
+chmod +x docker_server.sh
+echo -e "${GREEN}✓ docker_server.sh${NC}"
+
 # Set permissions for setup permissions script itself
 chmod +x setup_permissions.sh
 echo -e "${GREEN}✓ setup_permissions.sh${NC}"

--- a/scripts/start_all_servers.sh
+++ b/scripts/start_all_servers.sh
@@ -8,6 +8,59 @@ BLUE='\033[0;34m'
 CYAN='\033[0;36m'
 NC='\033[0m' # No Color
 
+# Function to check if screen is installed
+check_screen_installed() {
+    if ! command -v screen &> /dev/null; then
+        return 1
+    else
+        return 0
+    fi
+}
+
+# Function to install screen based on the OS package manager
+install_screen() {
+    # Detect package manager
+    if command -v apt &> /dev/null; then
+        echo -e "${BLUE}Installing screen via apt...${NC}"
+        sudo apt update && sudo apt install -y screen
+    elif command -v dnf &> /dev/null; then
+        echo -e "${BLUE}Installing screen via dnf...${NC}"
+        sudo dnf install -y screen
+    elif command -v yum &> /dev/null; then
+        echo -e "${BLUE}Installing screen via yum...${NC}"
+        sudo yum install -y screen
+    elif command -v apk &> /dev/null; then
+        echo -e "${BLUE}Installing screen via apk...${NC}"
+        sudo apk add screen
+    else
+        echo -e "${RED}✗ Unable to determine package manager.${NC}"
+        echo -e "${YELLOW}Please install 'screen' manually and run this script again.${NC}"
+        echo -e "${BLUE}Common installation commands:${NC}"
+        echo "  • Debian/Ubuntu: sudo apt install screen"
+        echo "  • Fedora: sudo dnf install screen"
+        echo "  • CentOS/RHEL: sudo yum install screen"
+        echo "  • Alpine: sudo apk add screen"
+        exit 1
+    fi
+}
+
+# Check and install screen if necessary
+if ! check_screen_installed; then
+    echo -e "${YELLOW}⚠ The 'screen' package is not installed. It is required to run servers in the background.${NC}"
+    echo -e "${BLUE}Attempting automatic installation...${NC}"
+    install_screen
+
+    # Check if installation was successful
+    if ! check_screen_installed; then
+        echo -e "${RED}✗ Installation of 'screen' failed.${NC}"
+        exit 1
+    else
+        echo -e "${GREEN}✓ 'screen' has been successfully installed.${NC}"
+    fi
+else
+    echo -e "${GREEN}✓ 'screen' is already installed.${NC}"
+fi
+
 echo -e "${GREEN}========== Start All Game Servers ==========${NC}"
 echo
 
@@ -53,15 +106,20 @@ current_dir=$(pwd)
 
 for dir in "${server_dirs[@]}"; do
     if [ -f "$dir/StarDeception.dedicated_server.sh" ]; then
-        echo -e "${BLUE}Starting server in $dir...${NC}"
+        session_name="$(basename "$dir")_session"
+        echo -e "${BLUE}Starting server in $dir (screen: $session_name)...${NC}"
         cd "$dir"
         chmod +x StarDeception.dedicated_server.sh
-        nohup ./StarDeception.dedicated_server.sh > server.log 2>&1 &
-        server_pid=$!
-        echo -e "${GREEN}  ✓ Server started with PID: $server_pid${NC}"
-        ((started_count++))
-        cd "$current_dir"  # Return to original directory
-        sleep 1  # Small delay between server starts
+        # Start the server in a detached screen session
+        screen -dmS "$session_name" bash -c './StarDeception.dedicated_server.sh > server.log 2>&1'
+        if screen -list | grep -q "$session_name"; then
+            echo -e "${GREEN}  ✓ Server started in screen session: $session_name${NC}"
+            ((started_count++))
+        else
+            echo -e "${RED}  ✗ Failed to start server in screen session: $session_name${NC}"
+        fi
+        cd "$current_dir"
+        sleep 1
     else
         echo -e "${YELLOW}  ⚠ Warning: StarDeception.dedicated_server.sh not found in $dir${NC}"
     fi
@@ -72,8 +130,9 @@ if [ $started_count -gt 0 ]; then
     echo -e "${GREEN}✓ Successfully started $started_count server(s)!${NC}"
     echo -e "${BLUE}📋 Server management tips:${NC}"
     echo "  • Check individual server.log files in each server directory for output"
-    echo "  • To stop all servers: pkill -f StarDeception.dedicated_server"
-    echo "  • To check running servers: ps aux | grep StarDeception"
+    echo "  • To stop all servers: screen -ls | grep '_session' | awk '{print \$1}' | xargs -I{} screen -S {} -X quit"
+    echo "  • To check running servers: screen -ls | grep '_session'"
+    echo "  • To attach to a server: screen -r <session_name> (ex: screen -r server1_session)"
 else
     echo -e "${RED}✗ No servers were started${NC}"
 fi


### PR DESCRIPTION
This pull request introduces Docker integration for managing StarDeception game servers and improves server management by utilizing `screen` sessions for running servers in the background.

### Docker Integration

- **New Docker Menu Option in Main Script**: Added a "Docker servers" option to the main menu (`Foundry.sh`) to manage Docker-based servers. This includes checks for the required `docker_server.sh` script. [[1]](diffhunk://#diff-2e9bc2e45b4c8c5c389e99f4173ce518c16265378c466270c0d458afdf33df9fL38-R41) [[2]](diffhunk://#diff-2e9bc2e45b4c8c5c389e99f4173ce518c16265378c466270c0d458afdf33df9fR286-R312) [[3]](diffhunk://#diff-2e9bc2e45b4c8c5c389e99f4173ce518c16265378c466270c0d458afdf33df9fR338-R359)
- **Docker Server Management Script**: Introduced `scripts/docker_server.sh` to handle Docker operations such as creating Docker containers, installing Docker if missing, and managing server containers.
- **Permission Setup for Docker Script**: Updated `scripts/setup_permissions.sh` to ensure the `docker_server.sh` script has execute permissions.

### Server Management Enhancements

- **Use of `screen` for Background Processes**: Updated `scripts/start_all_servers.sh` to use `screen` sessions for running servers, enabling easier management and monitoring of server processes. [[1]](diffhunk://#diff-3d51b11e7353f6a663a1701b060f575158a2887d86e83c29ad7171fbdaa4da7bR11-R63) [[2]](diffhunk://#diff-3d51b11e7353f6a663a1701b060f575158a2887d86e83c29ad7171fbdaa4da7bL56-R122) [[3]](diffhunk://#diff-3d51b11e7353f6a663a1701b060f575158a2887d86e83c29ad7171fbdaa4da7bL75-R135)
- **Improved Server Status Check**: Enhanced `scripts/status_servers.sh` to check for servers running in `screen` sessions and provide detailed management tips. [[1]](diffhunk://#diff-be2a37510abe407da4d4e0839e3836416febe7dd9f61d625cfe654c22af8b463L14-R73) [[2]](diffhunk://#diff-be2a37510abe407da4d4e0839e3836416febe7dd9f61d625cfe654c22af8b463L76-R123)
- **Stopping Servers via `screen`**: Modified `scripts/stop_all_servers.sh` to stop servers running in `screen` sessions instead of relying on process IDs.

### Documentation Updates

- **Acknowledgment for Docker Integration**: Added credit for Docker integration development to the `README.md`.